### PR TITLE
tui(intro): shorter wordmark + improved lowercase r

### DIFF
--- a/codex-rs/tui/src/glitch_animation.rs
+++ b/codex-rs/tui/src/glitch_animation.rs
@@ -508,7 +508,8 @@ fn scaled_mask(word: &str, max_w: u16, max_h: u16) -> (usize, Vec<Vec<bool>>, us
     let cols = letters.len() * w + (letters.len().saturating_sub(1)) * gap;
 
     // Start with an even smaller scale to prevent it from getting massive on wide terminals
-    let mut scale = 3usize;
+    // Start a bit smaller to keep the intro wordmark from getting too tall
+    let mut scale = 2usize;
     while scale > 1 && (cols * scale > max_w as usize || rows * scale > max_h as usize) {
         scale -= 1;
     }
@@ -550,8 +551,9 @@ fn glyph_5x7(ch: char) -> [&'static str; 7] {
         'a' => [
             "     ", "     ", " ### ", "    #", " ####", "#   #", " ####",
         ],
+        // Slimmer lowercase "r" with a cleaner stem; easier to read at small scales
         'r' => [
-            "     ", "     ", "#### ", "#   #", "#### ", "# #  ", "# #  ",
+            "     ", "     ", "#### ", "#   #", "#    ", "#    ", "#    ",
         ],
         't' => [
             "  #  ", "  #  ", " ### ", "  #  ", "  #  ", "  #  ", "  #  ",

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -2499,7 +2499,8 @@ impl HistoryCell for AnimatedWelcomeCell {
         // Estimated column width for the intro word (6 letters * 5 cols + 5 gaps).
         let cols: u16 = (6 * 5 + 5) as u16; // SMARTY
         let base_rows: u16 = 7;
-        let max_scale: u16 = 3;
+        // Keep intro slightly shorter by capping scale
+        let max_scale: u16 = 2;
         let scale = if width >= cols {
             (width / cols).min(max_scale).max(1)
         } else {


### PR DESCRIPTION
- Scale: 3→2 to reduce intro height\n- Cap welcome height scale to 2 for visual consistency\n- Glyph: slimmer lowercase 'r' for better legibility at small sizes