### PR TITLE
intro: classic lowercase 'r' default; remove variants

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -2508,8 +2508,8 @@ impl HistoryCell for AnimatedWelcomeCell {
         };
         let h = base_rows.saturating_mul(scale);
         self.locked_height.set(Some(h));
-        // Add a little padding below to give extra spacing
-        h.saturating_add(3)
+        // Reduce bottom padding to keep layout tight under the logo
+        h.saturating_add(1)
     }
 
     fn has_custom_render(&self) -> bool {


### PR DESCRIPTION
- Lock the lowercase 'r' to classic 5x7.\n- Keep height compression and reduced padding.\n- No env variants left.