### PR TITLE
fix(build): restore custom Cargo profiles for upstream compatibility

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -50,6 +50,30 @@ strip = "symbols"
 # See https://github.com/openai/codex/issues/1411 for details.
 codegen-units = 1
 
+# Custom build profiles used by build-fast.sh
+[profile.dev-fast]
+inherits = "dev"
+opt-level = 1
+debug = 1
+incremental = true
+codegen-units = 256
+lto = "off"
+
+[profile.perf]
+inherits = "release"
+incremental = true
+codegen-units = 256
+lto = "off"
+debug = 2
+strip = "none"
+split-debuginfo = "packed"
+
+[profile.release-prod]
+inherits = "release"
+lto = "fat"
+strip = "symbols"
+codegen-units = 1
+
 [patch.crates-io]
 # ratatui = { path = "../../ratatui" }
 ratatui = { git = "https://github.com/nornagon/ratatui", branch = "nornagon-v0.29.0-patch" }


### PR DESCRIPTION
## Problem

The upstream-merge workflow has been failing with:
```
error: profile `dev-fast` is not defined
```

## Root Cause

Commit a5ede3ae ("feat(overlay): isolate smarty seams") accidentally removed custom Cargo profiles that exist in upstream `openai/codex`.

## Solution

Restore the three custom profiles to match upstream:
- **dev-fast**: Fast incremental builds (default for `build-fast.sh`)
- **perf**: Release build with debug symbols for profiling  
- **release-prod**: Fully optimized production build

## Testing

- ✅ Profiles match upstream `openai/codex` exactly
- ✅ `build-fast.sh` will now work without errors
- ✅ Future upstream merges won't conflict on these profiles

## Upstream Reference

These profiles exist in `openai/codex` and are required by the build infrastructure.

Fixes workflow run: https://github.com/Smarty-Pants-Inc/code/actions/runs/18213083985